### PR TITLE
Increase Icon Size

### DIFF
--- a/apps/web/src/components/home/hero.tsx
+++ b/apps/web/src/components/home/hero.tsx
@@ -126,7 +126,7 @@ export function Hero() {
 										rel="noopener noreferrer"
 										aria-label={social.label}
 									>
-										<social.icon className="h-5 w-5" />
+										<social.icon className="h-6 w-6" />
 									</a>
 								</Button>
 							</motion.div>


### PR DESCRIPTION
Heroセクションのソーシャルメディアアイコン（GitHub、Twitter、Instagram）のサイズをh-5 w-5からh-6 w-6に変更し、視認性を向上させました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)