### PR TITLE
fix: Cloudflare Pages Deploy時のAPI Token権限エラーを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,7 @@ jobs:
         working-directory: apps/web
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: bunx wrangler pages deploy dist --project-name=burio-com
 
       - name: Deployment Summary


### PR DESCRIPTION
変更内容:
- Deploy Frontend (Cloudflare Pages)ステップにCLOUDFLARE_ACCOUNT_IDを追加
- Server deployと同様に両方の環境変数を設定

問題:
Cloudflare Pages Deployで以下のエラーが発生:
- A request to the Cloudflare API (/memberships) failed
- Authentication error [code: 10000]

原因:
- CLOUDFLARE_API_TOKENのみ設定されていた
- CLOUDFLARE_ACCOUNT_IDが欠落していた

解決策:
Server deployと同様に、Pages deployにも両方の環境変数を設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)