### PR TITLE
fix: 本番ビルド時のVITE_SERVER_URL環境変数を設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,7 @@ jobs:
         working-directory: apps/web
         env:
           NODE_ENV: production
+          VITE_SERVER_URL: https://burio-com-server.koutarouhanabusa.workers.dev
         run: bun run build
 
       - name: Deploy Frontend (Cloudflare Pages)


### PR DESCRIPTION
問題:
本番環境でブログ記事が読み込めず、以下のエラーが発生：
- "Unexpected token '<', \"<!DOCTYPE \"... is not valid JSON"
- APIリクエストURLが "/undefined/trpc/blog.getAll" になっていた

原因:
GitHub Actionsのデプロイワークフローで、
フロントエンドのビルド時にVITE_SERVER_URL環境変数が
設定されていなかったため、import.meta.env.VITE_SERVER_URLが
undefinedになっていた。

解決:
deploy.ymlの「Build Frontend」ステップに
VITE_SERVER_URL環境変数を追加し、
正しいサーバーURLを設定。

検証:
- ローカルでビルドを実行し、distファイルに 正しいURLが埋め込まれていることを確認
- /undefined/trpc ではなく、 /burio-com-server.koutarouhanabusa.workers.dev/trpc が埋め込まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)