### PR TITLE
fix: Cloudflare Workersのデプロイ設定を既存のburio-com-serverに統一

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: bunx wrangler deploy --env production
+        run: bunx wrangler deploy
 
       - name: Build Frontend
         working-directory: apps/web

--- a/apps/server/wrangler.jsonc
+++ b/apps/server/wrangler.jsonc
@@ -40,27 +40,6 @@
 		}
 	],
 	"env": {
-		"production": {
-			"d1_databases": [
-				{
-					"binding": "DB",
-					"database_name": "burio-com-db",
-					"database_id": "7390edad-195a-4da4-80a8-90209083afcc",
-					"migrations_dir": "./src/db/migrations"
-				}
-			],
-			"r2_buckets": [
-				{
-					"binding": "R2_BUCKET",
-					"bucket_name": "burio-com-blog"
-				}
-			],
-			"vars": {
-				"NODE_ENV": "production",
-				"CORS_ORIGIN": "https://burio16.com",
-				"BETTER_AUTH_URL": "https://api.burio16.com"
-			}
-		},
 		"dev": {
 			"d1_databases": [
 				{

--- a/apps/server/wrangler.toml
+++ b/apps/server/wrangler.toml
@@ -4,6 +4,11 @@ compatibility_date = "2025-06-15"
 compatibility_flags = ["nodejs_compat"]
 workers_dev = true
 
+# Custom Domain Routing
+routes = [
+  { pattern = "api.burio16.com/*", zone_name = "burio16.com" }
+]
+
 [vars]
 NODE_ENV = "production"
 CORS_ORIGIN = "https://burio16.com"


### PR DESCRIPTION
問題:
- deploy.ymlで`--env production`を使用していたため、 新しいWorker `burio-com-server-production`が作成され、 既存の`burio-com-server`へのルーティングが機能しなくなっていた

修正内容:
1. deploy.ymlから`--env production`を削除
2. wrangler.jsonc の env.production セクションを削除
3. wrangler.toml にカスタムドメインルーティングを追加
   - api.burio16.com/* → burio-com-server

これにより、既存のWorker `burio-com-server`を使い続けることができ、
CDでも正しくデプロイされるようになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)