### PR TITLE
fix: ブログ記事ページのOGP画像重複を解消

### DIFF
--- a/apps/web/functions/blog/_middleware.tsx
+++ b/apps/web/functions/blog/_middleware.tsx
@@ -139,7 +139,7 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 	const ogHandler = vercelOGPagesPlugin<{ env: Env }>({
 		imagePathSuffix: "/og-image",
 		autoInject: {
-			openGraph: true,
+			openGraph: false,
 		},
 		options: {
 			width: 1200,

--- a/apps/web/src/routes/blog/$id.tsx
+++ b/apps/web/src/routes/blog/$id.tsx
@@ -151,7 +151,7 @@ function BlogPostPage() {
 			<SEO
 				title={post.title}
 				description={post.excerpt || undefined}
-				image={post.coverImage || undefined}
+				image={post.coverImage || `https://burio16.com/blog/${id}/og-image`}
 				url={currentUrl}
 				type="article"
 			/>


### PR DESCRIPTION
変更内容:
1. Cloudflare Pluginの自動注入を無効化
   - autoInject.openGraph: true → false に変更
   - プラグインは画像生成のみを担当

2. 動的OGP画像URLを明示的に指定
   - image={post.coverImage || `https://burio16.com/blog/${id}/og-image`}
   - SEOコンポーネントで動的OGP画像を使用

これにより:
- og:imageメタタグの重複が解消
- ブログ記事: 動的OGP画像（タイトル付き）
- その他のページ: デフォルトOGP画像
- SNSシェア時に正しいOGP画像が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)