### PR TITLE
fix: モバイルパフォーマンスと「ぶりお」改行問題を修正

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,21 +1,6 @@
 <!DOCTYPE html>
 <html lang="ja">
   <head>
-    <!-- Google Tag Manager -->
-    <script>
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != "dataLayer" ? "&l=" + l : "";
-        j.async = true;
-        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-        f.parentNode.insertBefore(j, f);
-      })(window, document, "script", "dataLayer", "GTM-NSXW6XSJ");
-    </script>
-    <!-- End Google Tag Manager -->
-
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#ff914d" />
@@ -78,5 +63,30 @@
     <!-- End Google Tag Manager (noscript) -->
     <div id="app"></div>
     <script type="module" src="/src/main.tsx"></script>
+
+    <!-- Google Tag Manager - Deferred Loading for better LCP -->
+    <script>
+      // Load GTM after page load to improve LCP performance
+      function loadGTM() {
+        (function (w, d, s, l, i) {
+          w[l] = w[l] || [];
+          w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+          var f = d.getElementsByTagName(s)[0],
+            j = d.createElement(s),
+            dl = l != "dataLayer" ? "&l=" + l : "";
+          j.async = true;
+          j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+          f.parentNode.insertBefore(j, f);
+        })(window, document, "script", "dataLayer", "GTM-NSXW6XSJ");
+      }
+
+      // Use requestIdleCallback if available, otherwise fallback to setTimeout
+      if ("requestIdleCallback" in window) {
+        requestIdleCallback(loadGTM);
+      } else {
+        setTimeout(loadGTM, 1);
+      }
+    </script>
+    <!-- End Google Tag Manager -->
   </body>
 </html>

--- a/apps/web/src/components/home/hero.tsx
+++ b/apps/web/src/components/home/hero.tsx
@@ -19,13 +19,34 @@ const NAME_CHARACTERS = ["ぶ", "り", "お"] as const;
 
 export function Hero() {
 	const [enableAnimations, setEnableAnimations] = useState(false);
+	const [isMobile, setIsMobile] = useState(false);
 
 	useEffect(() => {
+		// Check if device is mobile (only in browser environment)
+		const checkMobile = () => {
+			if (typeof window !== "undefined") {
+				setIsMobile(window.innerWidth < 768);
+			}
+		};
+
+		checkMobile();
+
+		if (typeof window !== "undefined") {
+			window.addEventListener("resize", checkMobile);
+		}
+
 		// Enable animations after initial render for better LCP
 		// This ensures critical content is visible immediately
+		// On mobile, animations are simplified for better performance
 		requestAnimationFrame(() => {
 			setEnableAnimations(true);
 		});
+
+		return () => {
+			if (typeof window !== "undefined") {
+				window.removeEventListener("resize", checkMobile);
+			}
+		};
 	}, []);
 
 	/**
@@ -45,7 +66,7 @@ export function Hero() {
 	return (
 		<motion.section
 			className="flex min-h-screen items-center justify-center px-6 py-20"
-			initial={enableAnimations ? "hidden" : "visible"}
+			initial={enableAnimations && !isMobile ? "hidden" : "visible"}
 			animate="visible"
 			variants={sectionVariants}
 			transition={smoothTransition}
@@ -53,8 +74,8 @@ export function Hero() {
 			<div className="w-full max-w-4xl">
 				<div className="space-y-6">
 					<motion.div
-						className="inline-block text-balance font-bold text-5xl tracking-tight md:text-7xl"
-						initial={enableAnimations ? "hidden" : "visible"}
+						className="inline-block whitespace-nowrap text-balance font-bold text-5xl tracking-tight md:text-7xl"
+						initial={enableAnimations && !isMobile ? "hidden" : "visible"}
 						animate="visible"
 						whileHover="hover"
 						variants={heroTitleVariants}
@@ -64,12 +85,13 @@ export function Hero() {
 							<motion.span
 								key={char}
 								className="inline-block"
-								initial={enableAnimations ? "hidden" : "visible"}
+								initial={enableAnimations && !isMobile ? "hidden" : "visible"}
 								animate="visible"
 								whileHover="hover"
 								variants={characterVariants}
 								transition={{
-									delay: enableAnimations ? getStaggerDelay(i, 0.4) : 0,
+									delay:
+										enableAnimations && !isMobile ? getStaggerDelay(i, 0.4) : 0,
 									...springTransition,
 								}}
 							>
@@ -80,11 +102,11 @@ export function Hero() {
 
 					<motion.p
 						className="text-muted-foreground text-xl md:text-2xl"
-						initial={enableAnimations ? "hidden" : "visible"}
+						initial={enableAnimations && !isMobile ? "hidden" : "visible"}
 						animate="visible"
 						variants={fadeInUpVariants}
 						transition={{
-							delay: enableAnimations ? 0.4 : 0,
+							delay: enableAnimations && !isMobile ? 0.4 : 0,
 							...smoothTransition,
 						}}
 					>
@@ -93,11 +115,11 @@ export function Hero() {
 
 					<motion.p
 						className="max-w-2xl text-lg text-muted-foreground leading-relaxed"
-						initial={enableAnimations ? "hidden" : "visible"}
+						initial={enableAnimations && !isMobile ? "hidden" : "visible"}
 						animate="visible"
 						variants={fadeInUpVariants}
 						transition={{
-							delay: enableAnimations ? 0.6 : 0,
+							delay: enableAnimations && !isMobile ? 0.6 : 0,
 							...smoothTransition,
 						}}
 					>
@@ -110,22 +132,25 @@ export function Hero() {
 
 					<motion.div
 						className="flex gap-6 pt-4"
-						initial={enableAnimations ? "hidden" : "visible"}
+						initial={enableAnimations && !isMobile ? "hidden" : "visible"}
 						animate="visible"
 						variants={fadeInUpVariants}
 						transition={{
-							delay: enableAnimations ? 0.8 : 0,
+							delay: enableAnimations && !isMobile ? 0.8 : 0,
 							...smoothTransition,
 						}}
 					>
 						{SOCIAL_LINKS.map((social, index) => (
 							<motion.div
 								key={social.label}
-								initial={enableAnimations ? "hidden" : "visible"}
+								initial={enableAnimations && !isMobile ? "hidden" : "visible"}
 								animate="visible"
 								variants={socialIconVariants}
 								transition={{
-									delay: enableAnimations ? getStaggerDelay(index, 1.0) : 0,
+									delay:
+										enableAnimations && !isMobile
+											? getStaggerDelay(index, 1.0)
+											: 0,
 									duration: 0.3,
 								}}
 							>


### PR DESCRIPTION
## 概要

モバイル環境でのパフォーマンス改善と、「ぶりお」テキストが改行される問題を修正しました。

## 修正内容

### 1. 「ぶりお」テキストの改行問題を修正
- **問題**: モバイル表示時に「ぶ りお」と改行されて表示される
- **原因**: 各文字が`inline-block`の`motion.span`として配置されていた
- **修正**: 親要素に`whitespace-nowrap`を追加して強制的に1行表示

### 2. Google Tag Manager を遅延ロード化
- **問題**: GTM (731.8kB) が`<head>`で即座に読み込まれ、LCPに影響
- **修正**: `requestIdleCallback`または`setTimeout`でページロード後に読み込むように変更
- **効果**: 初期ロードのパフォーマンス改善

### 3. モバイルでアニメーションを簡素化
- **問題**: モバイル環境でのLCP Render Delayが632ms（デスクトップの5倍以上）
- **修正**: 画面幅768px未満ではアニメーションを無効化
- **効果**: モバイルでのRender Delay削減

## パフォーマンス改善

### モバイルLighthouseスコア（Slow 4G, CPU 4x）
**修正前:**
- LCP: 831ms
  - TTFB: 199ms (23.9%)
  - **Render delay: 632ms (76.1%)** ← 主要な問題

**期待される改善:**
- GTMの遅延ロードによりRender Delayが削減
- アニメーション無効化により更なるRender Delay削減

## テスト

- ✅ 型チェック通過
- ✅ ビルド成功
- ✅ ローカルでモバイル表示確認
- ⚠️ Unit test: 既存の問題により失敗（別issue対応予定）

## スクリーンショット

修正後のモバイル表示で「ぶりお」が1行で表示されることを確認済み。

## 注意事項

- `window.innerWidth`のチェックには`typeof window !== "undefined"`を追加し、SSR/テスト環境でのエラーを防止

## 参考

- [Lighthouseスコア調査結果](/Users/1126buri/dev/knowledge/2025-10-27/mobile-lighthouse-analysis.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)