### PR TITLE
fix: Twitter OGP重複問題を修正

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,7 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 import {
 	createRootRouteWithContext,
-	HeadContent,
 	Outlet,
 	useRouterState,
 } from "@tanstack/react-router";
@@ -43,23 +42,6 @@ export interface RouterAppContext {
 export const Route = createRootRouteWithContext<RouterAppContext>()({
 	component: RootComponent,
 	notFoundComponent: NotFound,
-	head: () => ({
-		meta: [
-			{
-				title: "burio16.com",
-			},
-			{
-				name: "description",
-				content: "burio16.com is a web application",
-			},
-		],
-		links: [
-			{
-				rel: "icon",
-				href: "/favicon.ico",
-			},
-		],
-	}),
 });
 
 function RootComponent() {
@@ -69,7 +51,6 @@ function RootComponent() {
 
 	return (
 		<HelmetProvider>
-			<HeadContent />
 			<ThemeProvider
 				attribute="class"
 				defaultTheme="dark"


### PR DESCRIPTION
TanStack Routerのhead設定を削除し、
全てのメタタグ管理をreact-helmet-asyncに統一。

問題:
- ブログ詳細ページでTwitterメタタグが重複
- __root.tsxのheadとreact-helmet-asyncが競合
- Twitterは最初のメタタグを使用するため、古い値が優先されていた

解決策:
- __root.tsxからhead設定とHeadContentインポートを削除
- react-helmet-asyncが適切にメタタグを管理

これにより、ブログ詳細ページのTwitter OGPが正しく表示されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)