### PR TITLE
fix: ブログ詳細ページのTwitter OGP URLを修正

### DIFF
--- a/apps/web/src/routes/blog/$id.tsx
+++ b/apps/web/src/routes/blog/$id.tsx
@@ -144,8 +144,6 @@ function BlogPostPage() {
 		);
 	}
 
-	const currentUrl = typeof window !== "undefined" ? window.location.href : "";
-
 	return (
 		<main className="min-h-screen">
 			<SEO
@@ -155,7 +153,7 @@ function BlogPostPage() {
 					post.coverImage ||
 					`${import.meta.env.VITE_SERVER_URL}/blog/${id}/og-image`
 				}
-				url={currentUrl}
+				url={`https://burio16.com/blog/${id}`}
 				type="article"
 			/>
 			<motion.article


### PR DESCRIPTION
## 概要
TwitterでブログページのOGPが表示されない問題を修正しました。

## 問題
- `https://burio16.com/blog/1` でTwitter OGPが表示されない
- 原因: `twitter:url`メタタグが常に`https://burio16.com/`になっていた

## 修正内容
- ブログ詳細ページのURLをルートパラメータから正しく構築するように変更
- `apps/web/src/routes/blog/$id.tsx:147`を修正

## 変更前
```typescript
const currentUrl = typeof window !== "undefined" ? window.location.href : "";
// SSR時に空文字列になり、デフォルト値が使われる
```

## 変更後
```typescript
url={\`https://burio16.com/blog/\${id}\`}
// ルートパラメータから正しいURLを構築
```

## 確認済み
- ✅ OGP画像エンドポイント (`/blog/:id/og-image`) は正常に動作
- ✅ 動的OGP画像が正しく生成されている
- ✅ メタタグの構造は正しい

## 残タスク
- R2バケットのOGPテンプレート画像が`burio.com_ogp.png`と一致しているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)