### PR TITLE
fix: OGP画像生成でR2バケットを優先的に使用するように変更

### DIFF
--- a/apps/server/src/routes/og-image.tsx
+++ b/apps/server/src/routes/og-image.tsx
@@ -54,10 +54,11 @@ export async function generateOgImage(c: Context) {
 					);
 					const r2Object = await c.env.R2_BUCKET.get("burio.com_ogp.png");
 					if (r2Object) {
-						imageData = await r2Object.arrayBuffer();
+						const fetchedData = await r2Object.arrayBuffer();
+						imageData = fetchedData;
 						console.log(
 							"Successfully fetched image from R2, size:",
-							imageData.byteLength,
+							fetchedData.byteLength,
 							"bytes",
 						);
 					} else {
@@ -84,8 +85,9 @@ export async function generateOgImage(c: Context) {
 				);
 
 				if (imageResponse.ok) {
-					imageData = await imageResponse.arrayBuffer();
-					console.log("Image data size:", imageData.byteLength, "bytes");
+					const fetchedData = await imageResponse.arrayBuffer();
+					imageData = fetchedData;
+					console.log("Image data size:", fetchedData.byteLength, "bytes");
 				} else {
 					console.error(
 						"Failed to fetch image, status:",


### PR DESCRIPTION
- R2バケットから画像を取得できない場合にHTTPSにフォールバック
- ベース画像の上にタイトルが表示されるようになった
- 詳細なデバッグログを追加してトラブルシューティングを改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)