### PR TITLE
fix: index.htmlから静的OGPタグを削除

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -10,24 +10,6 @@
     />
     <title>burio16.com</title>
 
-    <!-- Open Graph Protocol -->
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="burio16.com" />
-    <meta property="og:title" content="burio16.com　ぶりおのプロフィールサイト" />
-    <meta property="og:description" content="burio16.comへようこそ" />
-    <meta property="og:url" content="https://burio16.com/" />
-    <meta property="og:image" content="https://burio16.com/burio.com_ogp.png" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
-    <meta property="og:locale" content="ja_JP" />
-
-    <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:url" content="https://burio16.com/" />
-    <meta name="twitter:title" content="burio16.com　ぶりおのプロフィールサイト" />
-    <meta name="twitter:description" content="burio16.comへようこそ" />
-    <meta name="twitter:image" content="https://burio16.com/burio.com_ogp.png" />
-
     <!-- Canonical URL -->
     <link rel="canonical" href="https://burio16.com/" />
 


### PR DESCRIPTION
- react-helmet-asyncによる動的なOGPタグ生成のみに依存
- 記事固有のOGP画像が正しく表示されるようにする

🤖 Generated with [Claude Code](https://claude.com/claude-code)