### PR TITLE
fix: ブログ作成/更新後のナビゲーションをslugからidに変更

### DIFF
--- a/apps/web/src/routes/admin/blog/$id.edit.tsx
+++ b/apps/web/src/routes/admin/blog/$id.edit.tsx
@@ -56,7 +56,7 @@ function EditBlogPost() {
 	const updatePost = trpc.blog.update.useMutation({
 		onSuccess: (data) => {
 			toast.success("記事を更新しました");
-			navigate({ to: `/blog/${data.slug}` });
+			navigate({ to: `/blog/${data.id}` });
 		},
 		onError: (error) => {
 			toast.error(`エラー: ${error.message}`);

--- a/apps/web/src/routes/admin/blog/new.tsx
+++ b/apps/web/src/routes/admin/blog/new.tsx
@@ -36,7 +36,7 @@ function NewBlogPost() {
 	const createPost = trpc.blog.create.useMutation({
 		onSuccess: (data) => {
 			toast.success("記事を作成しました");
-			navigate({ to: `/blog/${data.slug}` });
+			navigate({ to: `/blog/${data.id}` });
 		},
 		onError: (error) => {
 			toast.error(`エラー: ${error.message}`);


### PR DESCRIPTION
- 作成・更新後にslugでナビゲートすると、idがNaNになり400エラーが発生
- ルートはidを期待しているため、data.idを使用するように修正
- これによりOGP画像生成が正常に動作するようになる

🤖 Generated with [Claude Code](https://claude.com/claude-code)