### PR TITLE
fix: OGP画像URLの先頭スペースを除去

### DIFF
--- a/apps/web/functions/_middleware.ts
+++ b/apps/web/functions/_middleware.ts
@@ -37,7 +37,7 @@ export async function onRequest(context: {
 	// HTMLを取得して書き換え
 	const html = await response.text();
 	const serverUrl =
-		env.VITE_SERVER_URL ||
+		env.VITE_SERVER_URL?.trim() ||
 		"https://burio-com-server.koutarouhanabusa.workers.dev";
 	const ogImageUrl = `${serverUrl}/blog/${postId}/og-image`;
 	const pageUrl = `https://burio16.com/blog/${postId}`;

--- a/apps/web/src/routes/blog/$id.tsx
+++ b/apps/web/src/routes/blog/$id.tsx
@@ -151,7 +151,7 @@ function BlogPostPage() {
 				description={post.excerpt || undefined}
 				image={
 					post.coverImage ||
-					`${import.meta.env.VITE_SERVER_URL}/blog/${id}/og-image`
+					`${import.meta.env.VITE_SERVER_URL?.trim() || ""}/blog/${id}/og-image`
 				}
 				url={`https://burio16.com/blog/${id}`}
 				type="article"


### PR DESCRIPTION
middlewareとブログ詳細ページで環境変数VITE_SERVER_URLを使用する際に、
trim()を追加して先頭・末尾のスペースを除去するように修正。

Cloudflare Pagesの環境変数に誤って先頭スペースが含まれている場合でも、
OGP画像が正しく表示されるようになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)