### PR TITLE
fix: OG画像をベース画像+タイトルに変更し、ブログ記事表示を修正

### DIFF
--- a/apps/server/src/routes/og-image.tsx
+++ b/apps/server/src/routes/og-image.tsx
@@ -38,7 +38,6 @@ ogImageRouter.get("/", async (c) => {
 		const idParam = c.req.query("id");
 
 		let title = "burio.com";
-		let subtitle = "Blog & Portfolio";
 
 		// IDが指定されている場合は、データベースから記事を取得
 		if (idParam) {
@@ -53,13 +52,20 @@ ogImageRouter.get("/", async (c) => {
 
 				if (post) {
 					title = post.title;
-					subtitle = "burio.com";
 				}
 			}
 		}
 
 		// フォントを取得
 		const notoSansFont = await getFont();
+
+		// ベース画像を取得
+		const baseImageUrl = "https://burio16.com/burio.com_ogp.png";
+		const baseImageResponse = await fetch(baseImageUrl);
+		const baseImageArrayBuffer = await baseImageResponse.arrayBuffer();
+		const baseImageBase64 = btoa(
+			String.fromCharCode(...new Uint8Array(baseImageArrayBuffer)),
+		);
 
 		// ImageResponseでOG画像を生成
 		return new ImageResponse(
@@ -68,71 +74,49 @@ ogImageRouter.get("/", async (c) => {
 					width: "100%",
 					height: "100%",
 					display: "flex",
-					flexDirection: "column",
-					alignItems: "center",
-					justifyContent: "center",
-					background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
-					fontFamily: '"Noto Sans JP", sans-serif',
-					padding: "60px",
+					position: "relative",
 				}}
 			>
-				{/* メインタイトル */}
-				<div
+				{/* ベース画像 */}
+				<img
+					src={`data:image/png;base64,${baseImageBase64}`}
+					alt="Base"
 					style={{
-						fontSize: "72px",
-						fontWeight: 700,
-						color: "white",
-						textAlign: "center",
-						marginBottom: "30px",
-						lineHeight: 1.2,
-						maxWidth: "1080px",
-						overflow: "hidden",
-						textOverflow: "ellipsis",
-						display: "-webkit-box",
-						WebkitLineClamp: 3,
-						WebkitBoxOrient: "vertical",
+						position: "absolute",
+						width: "100%",
+						height: "100%",
+						objectFit: "cover",
 					}}
-				>
-					{title}
-				</div>
+				/>
 
-				{/* サブタイトル/サイト名 */}
-				<div
-					style={{
-						fontSize: "36px",
-						fontWeight: 700,
-						color: "rgba(255, 255, 255, 0.9)",
-						textAlign: "center",
-					}}
-				>
-					{subtitle}
-				</div>
-
-				{/* 装飾的な要素 */}
+				{/* タイトルオーバーレイ */}
 				<div
 					style={{
 						position: "absolute",
-						bottom: "60px",
-						right: "60px",
-						width: "200px",
-						height: "200px",
-						borderRadius: "50%",
-						background: "rgba(255, 255, 255, 0.1)",
+						width: "100%",
+						height: "100%",
 						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						background: "rgba(0, 0, 0, 0.3)",
+						padding: "80px",
 					}}
-				/>
-				<div
-					style={{
-						position: "absolute",
-						top: "60px",
-						left: "60px",
-						width: "150px",
-						height: "150px",
-						borderRadius: "50%",
-						background: "rgba(255, 255, 255, 0.1)",
-						display: "flex",
-					}}
-				/>
+				>
+					<div
+						style={{
+							fontSize: "64px",
+							fontWeight: 700,
+							color: "white",
+							textAlign: "center",
+							lineHeight: 1.3,
+							maxWidth: "1000px",
+							textShadow: "2px 2px 8px rgba(0, 0, 0, 0.8)",
+							fontFamily: '"Noto Sans JP", sans-serif',
+						}}
+					>
+						{title}
+					</div>
+				</div>
 			</div>,
 			{
 				width: 1200,

--- a/apps/web/src/routes/blog/$id.tsx
+++ b/apps/web/src/routes/blog/$id.tsx
@@ -258,20 +258,22 @@ function BlogPostPage() {
 						</div>
 					</motion.header>
 
-					<motion.div
-						className="mb-8 overflow-hidden rounded-xl"
-						initial={{ opacity: 0, scale: 0.95 }}
-						animate={{ opacity: 1, scale: 1 }}
-						transition={{ delay: 0.4, duration: 0.6 }}
-					>
-						<img
-							src={post.coverImage || ogImageUrl}
-							alt={post.coverImage ? post.title : `${post.title} - OG Image`}
-							fetchPriority="high"
-							decoding="async"
-							className="h-auto w-full"
-						/>
-					</motion.div>
+					{post.coverImage && (
+						<motion.div
+							className="mb-8 overflow-hidden rounded-xl"
+							initial={{ opacity: 0, scale: 0.95 }}
+							animate={{ opacity: 1, scale: 1 }}
+							transition={{ delay: 0.4, duration: 0.6 }}
+						>
+							<img
+								src={post.coverImage}
+								alt={post.title}
+								fetchPriority="high"
+								decoding="async"
+								className="h-auto w-full"
+							/>
+						</motion.div>
+					)}
 
 					<motion.div
 						className="prose prose-lg dark:prose-invert max-w-none"


### PR DESCRIPTION
- coverImageがない記事でブログ本文に画像を表示しないよう修正
- OG画像生成でburio.com_ogp.pngをベースとして使用
- ベース画像の上にタイトルを半透明のオーバーレイで表示
- タイトルに影を追加して視認性を向上

🤖 Generated with [Claude Code](https://claude.com/claude-code)