### PR TITLE
fix: imgタグを使用してベース画像+タイトルのOG画像を生成

### DIFF
--- a/apps/server/src/routes/og-image.tsx
+++ b/apps/server/src/routes/og-image.tsx
@@ -69,42 +69,49 @@ ogImageRouter.get("/", async (c) => {
 					width: "100%",
 					height: "100%",
 					display: "flex",
-					alignItems: "center",
-					justifyContent: "center",
-					backgroundImage: `url(${baseImageUrl})`,
-					backgroundSize: "cover",
-					backgroundPosition: "center",
-					fontFamily: '"Noto Sans JP", sans-serif',
-					padding: "80px",
 					position: "relative",
 				}}
 			>
-				{/* 半透明オーバーレイ */}
+				{/* ベース画像 */}
+				<img
+					src={baseImageUrl}
+					alt="Base"
+					width="1200"
+					height="630"
+					style={{
+						position: "absolute",
+						width: "100%",
+						height: "100%",
+					}}
+				/>
+
+				{/* タイトルオーバーレイ */}
 				<div
 					style={{
 						position: "absolute",
 						width: "100%",
 						height: "100%",
-						background: "rgba(0, 0, 0, 0.4)",
-						top: 0,
-						left: 0,
-					}}
-				/>
-
-				{/* タイトル */}
-				<div
-					style={{
-						fontSize: "64px",
-						fontWeight: 700,
-						color: "white",
-						textAlign: "center",
-						lineHeight: 1.3,
-						maxWidth: "1000px",
-						zIndex: 10,
-						textShadow: "2px 2px 12px rgba(0, 0, 0, 0.9)",
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						background: "rgba(0, 0, 0, 0.5)",
+						fontFamily: '"Noto Sans JP", sans-serif',
+						padding: "80px",
 					}}
 				>
-					{title}
+					<div
+						style={{
+							fontSize: "72px",
+							fontWeight: 700,
+							color: "white",
+							textAlign: "center",
+							lineHeight: 1.3,
+							maxWidth: "1000px",
+							textShadow: "4px 4px 8px rgba(0, 0, 0, 0.9)",
+						}}
+					>
+						{title}
+					</div>
 				</div>
 			</div>,
 			{


### PR DESCRIPTION
backgroundImageではなくimgタグを使用してベース画像を表示。
burio.com_ogp.png（bのキャラクター）をベースとして、
その上に半透明オーバーレイとタイトルを表示する実装に変更。

変更内容:
- imgタグでベース画像を読み込み
- 半透明の黒いオーバーレイ（50%）で視認性を確保
- タイトルを白文字+強い影（4px）で表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)