### PR TITLE
fix: Remove unsupported CSS properties from OG image generation

### DIFF
--- a/apps/web/functions/blog/[id].png.tsx
+++ b/apps/web/functions/blog/[id].png.tsx
@@ -104,9 +104,6 @@ export const onRequest: PagesFunction<{
 							maxWidth: "100%",
 							overflow: "hidden",
 							textOverflow: "ellipsis",
-							display: "-webkit-box",
-							WebkitLineClamp: 3,
-							WebkitBoxOrient: "vertical",
 						}}
 					>
 						{post.title}
@@ -123,9 +120,6 @@ export const onRequest: PagesFunction<{
 								maxWidth: "100%",
 								overflow: "hidden",
 								textOverflow: "ellipsis",
-								display: "-webkit-box",
-								WebkitLineClamp: 2,
-								WebkitBoxOrient: "vertical",
 							}}
 						>
 							{post.excerpt}


### PR DESCRIPTION
- Remove WebkitLineClamp, WebkitBoxOrient, and display: "-webkit-box"
- These properties are not supported by satori (used by ImageResponse)
- Fixes 500 error when generating OG images

🤖 Generated with [Claude Code](https://claude.com/claude-code)