### PR TITLE
wrangler.tomlから[vars]を削除、ダッシュボードSecretsを使用

### DIFF
--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -3,15 +3,4 @@ compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "dist"
 
-# Production bindings (default for main branch)
-[vars]
-SERVER_URL = "https://api.burio16.com"
-R2_PUBLIC_URL = "https://pub-4c323738b7af49f59082cdff9645ae29.r2.dev"
-
-# Preview environment (for non-production branches)
-[env.preview]
-name = "burio-com-preview"
-
-[env.preview.vars]
-SERVER_URL = "https://api.burio16.com"
-R2_PUBLIC_URL = "https://pub-4c323738b7af49f59082cdff9645ae29.r2.dev"
+# Environment variables are managed via Cloudflare Dashboard (Secrets)


### PR DESCRIPTION
wrangler.tomlの[vars]がダッシュボード設定を上書きしていた問題を解決