### PR TITLE
keep_vars=trueを追加してダッシュボードの環境変数を維持

### DIFF
--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -2,5 +2,6 @@ name = "burio-com"
 compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "dist"
+keep_vars = true
 
 # Environment variables are managed via Cloudflare Dashboard (Secrets)


### PR DESCRIPTION
pages_build_output_dirがあるとwrangler.tomlがsource of truthになり ダッシュボード設定を上書きする問題を解決