### PR TITLE
feat: blog.burio16.comサブドメインでOGP対応

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -18,6 +18,7 @@ app.use(
 			"https://burio-com.koutarouhanabusa.workers.dev",
 			"https://burio-com.pages.dev",
 			"https://*.burio-com.pages.dev",
+			"https://blog.burio16.com",
 			"http://localhost:3001",
 			"http://localhost:3002",
 		].filter(Boolean),
@@ -44,7 +45,7 @@ app.get("/", (c) => {
 // OGP routes for api.burio16.com/ogp/*
 app.route("/ogp", ogp);
 
-// Blog routes for burio16.com/blog/* (via Cloudflare routing)
+// Blog routes for blog.burio16.com/* (via Cloudflare routing)
 app.route("", ogp);
 
 export default app;

--- a/apps/server/src/lib/ogp/image.tsx
+++ b/apps/server/src/lib/ogp/image.tsx
@@ -127,13 +127,22 @@ export async function generateOgImage(
 	bgImageUrl: string,
 ): Promise<Response> {
 	try {
-		const fontData = await fetch(FONT_URL).then((res) => {
-			if (!res.ok) throw new Error(`Font fetch failed: ${res.status}`);
-			return res.arrayBuffer();
-		});
+		// フォントと背景画像を並列で取得
+		const [fontData, bgImageData] = await Promise.all([
+			fetch(FONT_URL).then((res) => {
+				if (!res.ok) throw new Error(`Font fetch failed: ${res.status}`);
+				return res.arrayBuffer();
+			}),
+			fetch(bgImageUrl).then(async (res) => {
+				if (!res.ok) throw new Error(`BG image fetch failed: ${res.status}`);
+				const buffer = await res.arrayBuffer();
+				const base64 = btoa(String.fromCharCode(...new Uint8Array(buffer)));
+				return `data:image/png;base64,${base64}`;
+			}),
+		]);
 
 		const imageResponse = new ImageResponse(
-			<OgImageContent post={post} bgImageUrl={bgImageUrl} />,
+			<OgImageContent post={post} bgImageUrl={bgImageData} />,
 			{
 				width: 1200,
 				height: 630,

--- a/apps/server/src/routers/ogp.tsx
+++ b/apps/server/src/routers/ogp.tsx
@@ -59,7 +59,8 @@ async function fetchPagesHtml(pagesUrl: string, id: string): Promise<Response> {
 	return fetch(`${pagesUrl}/blog/${id}`);
 }
 
-ogp.get("/blog/:id/og.png", async (c: Context<{ Bindings: OgpEnv }>) => {
+// blog.burio16.com/:id/og.png - OGP画像
+ogp.get("/:id/og.png", async (c: Context<{ Bindings: OgpEnv }>) => {
 	const id = c.req.param("id");
 	const bgImageUrl = `${c.env.R2_PUBLIC_URL}/burio.com_ogp.png`;
 
@@ -75,10 +76,10 @@ ogp.get("/blog/:id/og.png", async (c: Context<{ Bindings: OgpEnv }>) => {
 	}
 });
 
-ogp.get("/blog/:id", async (c: Context<{ Bindings: OgpEnv }>) => {
+// blog.burio16.com/:id - ブログページ（メタタグ注入）
+ogp.get("/:id", async (c: Context<{ Bindings: OgpEnv }>) => {
 	const id = c.req.param("id");
 	const pagesUrl = c.env.PAGES_URL;
-	const apiUrl = new URL(c.req.url).origin;
 
 	try {
 		const [post, htmlResponse] = await Promise.all([
@@ -94,8 +95,8 @@ ogp.get("/blog/:id", async (c: Context<{ Bindings: OgpEnv }>) => {
 			});
 		}
 
-		const pageUrl = `https://burio16.com/blog/${post.id}`;
-		const ogImageUrl = `${apiUrl}/ogp/blog/${post.id}/og.png`;
+		const pageUrl = `https://blog.burio16.com/${post.id}`;
+		const ogImageUrl = `https://blog.burio16.com/${post.id}/og.png`;
 		const modifiedHtml = injectOGPMetaTags(html, post, pageUrl, ogImageUrl);
 
 		const headers = new Headers();

--- a/apps/server/wrangler.toml
+++ b/apps/server/wrangler.toml
@@ -7,7 +7,7 @@ workers_dev = true
 # Custom Domain Routing
 routes = [
   { pattern = "api.burio16.com/*", zone_name = "burio16.com" },
-  { pattern = "burio16.com/blog/*", zone_name = "burio16.com" }
+  { pattern = "blog.burio16.com/*", zone_name = "burio16.com" }
 ]
 
 [vars]

--- a/apps/web/public/_routes.json
+++ b/apps/web/public/_routes.json
@@ -1,5 +1,0 @@
-{
-	"version": 1,
-	"include": ["/*"],
-	"exclude": ["/blog/*"]
-}


### PR DESCRIPTION
- ルートをblog.burio16.com/*に変更
- OGP画像: blog.burio16.com/:id/og.png
- メタタグ注入: blog.burio16.com/:id
- 不要な_routes.json削除