### PR TITLE
fix(ogp): fetchハンドラーで環境変数を明示的に渡す

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -56,4 +56,12 @@ app.route("/ogp", ogp);
 // Blog routes for blog.burio16.com/* (via Cloudflare routing)
 app.route("", ogp);
 
-export default app;
+export default {
+	async fetch(
+		request: Request,
+		env: AppEnv["Bindings"],
+		ctx: ExecutionContext,
+	) {
+		return app.fetch(request, env, ctx);
+	},
+};


### PR DESCRIPTION
export default appだと環境変数がc.envに渡されないため、
明示的にfetchハンドラーを定義してenvを渡すよう修正