### PR TITLE
fix(ogp): hono/adapterのenv()ヘルパーを使用

### DIFF
--- a/apps/server/src/lib/ogp/types.ts
+++ b/apps/server/src/lib/ogp/types.ts
@@ -7,7 +7,8 @@ export interface BlogPost {
 	published: number | null;
 }
 
-export interface OgpEnv {
+export type OgpEnv = {
 	R2_PUBLIC_URL: string;
 	PAGES_URL: string;
-}
+	[key: string]: unknown;
+};

--- a/apps/server/src/routers/ogp.tsx
+++ b/apps/server/src/routers/ogp.tsx
@@ -1,13 +1,14 @@
 import { ImageResponse } from "@cloudflare/pages-plugin-vercel-og/api";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
+import { env } from "hono/adapter";
 import { db } from "../db";
 import { posts } from "../db/schema";
 import { generateOgImage } from "../lib/ogp/image";
 import { injectOGPMetaTags } from "../lib/ogp/meta";
 import type { BlogPost, OgpEnv } from "../lib/ogp/types";
 
-const ogp = new Hono<{ Bindings: OgpEnv }>();
+const ogp = new Hono();
 
 // シンプルなテストエンドポイント（外部リソースなし）
 ogp.get("/test.png", async (c) => {
@@ -61,7 +62,8 @@ async function fetchPagesHtml(pagesUrl: string, id: string): Promise<Response> {
 // blog.burio16.com/:id/og.png - OGP画像
 ogp.get("/:id/og.png", async (c) => {
 	const id = c.req.param("id");
-	const bgImageUrl = `${c.env.R2_PUBLIC_URL}/burio.com_ogp.png`;
+	const { R2_PUBLIC_URL } = env<OgpEnv>(c);
+	const bgImageUrl = `${R2_PUBLIC_URL}/burio.com_ogp.png`;
 
 	try {
 		const post = await fetchBlogPost(id);
@@ -78,7 +80,8 @@ ogp.get("/:id/og.png", async (c) => {
 // blog.burio16.com/:id - ブログページ（メタタグ注入）
 ogp.get("/:id", async (c) => {
 	const id = c.req.param("id");
-	const pagesUrl = c.env.PAGES_URL;
+	const { PAGES_URL } = env<OgpEnv>(c);
+	const pagesUrl = PAGES_URL;
 
 	console.log("OGP meta injection request:", { id, pagesUrl });
 


### PR DESCRIPTION
c.envが正しく動作しない問題を解決するため、
hono/adapterのenv()ヘルパーを使って環境変数を取得

参考: https://hono.dev/docs/helpers/adapter