### PR TITLE
fix(ogp): ReactインポートをPages Functionsに追加

### DIFF
--- a/apps/web/functions/blog/[[path]].tsx
+++ b/apps/web/functions/blog/[[path]].tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from "@cloudflare/pages-plugin-vercel-og/api";
+import React from "react";
 
 interface Env {
 	ASSETS: Fetcher;


### PR DESCRIPTION
JSXを使用するためにReactのインポートが必要だった。