### PR TITLE
fix(ogp): タイトル改行時の文字切れを修正

### DIFF
--- a/apps/web/functions/blog/[[path]].tsx
+++ b/apps/web/functions/blog/[[path]].tsx
@@ -218,11 +218,9 @@ function OgImageContent({
 							fontSize: "64px",
 							fontWeight: "bold",
 							color: "#ffffff",
-							lineHeight: 1.2,
+							lineHeight: 1.4,
 							marginBottom: "30px",
 							maxWidth: "100%",
-							overflow: "hidden",
-							textOverflow: "ellipsis",
 						}}
 					>
 						{title}


### PR DESCRIPTION
SatoriのCJKレンダリングでoverflow:hiddenとlineHeight:1.2の組み合わせにより 改行後のテキスト下部がクリップされていた問題を修正