### PR TITLE
feat: add link preview (OGP embed) for standalone URLs in blog posts

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -107,6 +107,107 @@ app.get("/r2/images/:filename", async (c) => {
 	return new Response(object.body, { headers });
 });
 
+app.get("/api/ogp", async (c) => {
+	const url = c.req.query("url");
+	if (!url) {
+		return c.json({ error: "URL is required" }, 400);
+	}
+
+	try {
+		// Validate URL
+		const parsedUrl = new URL(url);
+		if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+			return c.json({ error: "Invalid URL protocol" }, 400);
+		}
+
+		const response = await fetch(url, {
+			headers: {
+				"User-Agent": "bot",
+				Accept: "text/html",
+			},
+			redirect: "follow",
+			signal: AbortSignal.timeout(5000),
+		});
+
+		if (!response.ok) {
+			return c.json({ error: "Failed to fetch URL" }, 502);
+		}
+
+		const html = await response.text();
+
+		// Parse OGP meta tags
+		const getMetaContent = (property: string, html: string): string | null => {
+			// Match both property="" and name="" attributes
+			const regex = new RegExp(
+				`<meta[^>]*(?:property|name)=["']${property}["'][^>]*content=["']([^"']*)["']|<meta[^>]*content=["']([^"']*)["'][^>]*(?:property|name)=["']${property}["']`,
+				"i",
+			);
+			const match = html.match(regex);
+			return match ? match[1] || match[2] || null : null;
+		};
+
+		const getTitle = (html: string): string | null => {
+			const match = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+			return match ? match[1].trim() : null;
+		};
+
+		const getFavicon = (html: string, baseUrl: string): string | null => {
+			const match = html.match(
+				/<link[^>]*rel=["'](?:icon|shortcut icon)["'][^>]*href=["']([^"']*)["']/i,
+			);
+			if (match?.[1]) {
+				try {
+					return new URL(match[1], baseUrl).href;
+				} catch {
+					return null;
+				}
+			}
+			// Default favicon
+			try {
+				return new URL("/favicon.ico", baseUrl).href;
+			} catch {
+				return null;
+			}
+		};
+
+		const ogp = {
+			title:
+				getMetaContent("og:title", html) ||
+				getMetaContent("twitter:title", html) ||
+				getTitle(html) ||
+				"",
+			description:
+				getMetaContent("og:description", html) ||
+				getMetaContent("twitter:description", html) ||
+				getMetaContent("description", html) ||
+				"",
+			image:
+				getMetaContent("og:image", html) ||
+				getMetaContent("twitter:image", html) ||
+				"",
+			siteName: getMetaContent("og:site_name", html) || parsedUrl.hostname,
+			favicon: getFavicon(html, parsedUrl.origin),
+			url,
+		};
+
+		// Resolve relative image URLs
+		if (ogp.image && !ogp.image.startsWith("http")) {
+			try {
+				ogp.image = new URL(ogp.image, parsedUrl.origin).href;
+			} catch {
+				ogp.image = "";
+			}
+		}
+
+		return c.json(ogp, 200, {
+			"Cache-Control": "public, max-age=86400",
+		});
+	} catch (error) {
+		console.error("OGP fetch error:", error);
+		return c.json({ error: "Failed to fetch OGP data" }, 500);
+	}
+});
+
 app.get("/", (c) => {
 	return c.text("OK");
 });

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -133,3 +133,97 @@ body {
 		@apply text-foreground;
 	}
 }
+
+/* Link Preview Card */
+.link-preview {
+	margin: 1.5rem 0;
+}
+
+.link-preview-card {
+	display: flex;
+	overflow: hidden;
+	border: 1px solid var(--border);
+	border-radius: var(--radius);
+	text-decoration: none !important;
+	color: inherit !important;
+	transition: background-color 0.2s;
+}
+
+.link-preview-card:hover {
+	background-color: var(--accent);
+}
+
+.link-preview-image {
+	flex-shrink: 0;
+	width: 200px;
+	min-height: 100px;
+	overflow: hidden;
+}
+
+.link-preview-image img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	margin: 0 !important;
+	border-radius: 0 !important;
+	box-shadow: none !important;
+}
+
+.link-preview-body {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	gap: 0.25rem;
+	padding: 0.75rem 1rem;
+	min-width: 0;
+	flex: 1;
+}
+
+.link-preview-title {
+	font-weight: 600;
+	font-size: 0.95rem;
+	line-height: 1.4;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+}
+
+.link-preview-description {
+	font-size: 0.8rem;
+	color: var(--muted-foreground);
+	line-height: 1.4;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+}
+
+.link-preview-site {
+	display: flex;
+	align-items: center;
+	gap: 0.375rem;
+	font-size: 0.75rem;
+	color: var(--muted-foreground);
+}
+
+.link-preview-favicon {
+	width: 14px;
+	height: 14px;
+	border-radius: 2px;
+	margin: 0 !important;
+	box-shadow: none !important;
+}
+
+@media (max-width: 640px) {
+	.link-preview-card {
+		flex-direction: column;
+	}
+
+	.link-preview-image {
+		width: 100%;
+		height: 160px;
+	}
+}

--- a/apps/web/src/routes/admin/blog/$id.edit.tsx
+++ b/apps/web/src/routes/admin/blog/$id.edit.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import DOMPurify from "dompurify";
 import { motion } from "framer-motion";
 import { marked } from "marked";
-import { useEffect, useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { RiArrowLeftLine, RiEyeLine, RiSaveLine } from "react-icons/ri";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -10,6 +10,10 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useImageUpload } from "@/hooks/use-image-upload";
+import {
+	hydrateLinkPreviews,
+	linkPreviewExtension,
+} from "@/utils/link-preview";
 import { trpc } from "@/utils/trpc";
 
 export const Route = createFileRoute("/admin/blog/$id/edit")({
@@ -29,6 +33,7 @@ function EditBlogPost() {
 	const [htmlContent, setHtmlContent] = useState("");
 
 	const { textareaProps } = useImageUpload(setContent);
+	const previewRef = useRef<HTMLDivElement>(null);
 
 	// Generate unique IDs for form elements
 	const titleId = useId();
@@ -73,8 +78,10 @@ function EditBlogPost() {
 				breaks: true,
 				pedantic: false,
 			});
+			marked.use(linkPreviewExtension);
 			const rawHtml = marked(content) as string;
 			const cleanHtml = DOMPurify.sanitize(rawHtml, {
+				ADD_ATTR: ["data-url", "target", "rel"],
 				// プレビュー用の安全な設定
 				FORBID_TAGS: ["script", "object", "embed", "form", "input"],
 				FORBID_ATTR: ["onerror", "onload", "onclick", "onmouseover"],
@@ -83,6 +90,12 @@ function EditBlogPost() {
 		}
 		setPreview(!preview);
 	};
+
+	useEffect(() => {
+		if (preview && htmlContent && previewRef.current) {
+			hydrateLinkPreviews(previewRef.current);
+		}
+	}, [preview, htmlContent]);
 
 	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault();
@@ -246,6 +259,7 @@ function EditBlogPost() {
 								/>
 							)}
 							<div
+								ref={previewRef}
 								className="prose prose-lg dark:prose-invert max-w-none"
 								dangerouslySetInnerHTML={{ __html: htmlContent }}
 							/>

--- a/apps/web/src/routes/admin/blog/new.tsx
+++ b/apps/web/src/routes/admin/blog/new.tsx
@@ -2,13 +2,17 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import DOMPurify from "dompurify";
 import { motion } from "framer-motion";
 import { marked } from "marked";
-import { useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { RiArrowLeftLine, RiEyeLine, RiSaveLine } from "react-icons/ri";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useImageUpload } from "@/hooks/use-image-upload";
+import {
+	hydrateLinkPreviews,
+	linkPreviewExtension,
+} from "@/utils/link-preview";
 import { trpc } from "@/utils/trpc";
 
 export const Route = createFileRoute("/admin/blog/new")({
@@ -27,6 +31,7 @@ function NewBlogPost() {
 	const [htmlContent, setHtmlContent] = useState("");
 
 	const { textareaProps } = useImageUpload(setContent);
+	const previewRef = useRef<HTMLDivElement>(null);
 
 	// Generate unique IDs for form elements
 	const titleId = useId();
@@ -53,8 +58,10 @@ function NewBlogPost() {
 				breaks: true,
 				pedantic: false,
 			});
+			marked.use(linkPreviewExtension);
 			const rawHtml = marked(content) as string;
 			const cleanHtml = DOMPurify.sanitize(rawHtml, {
+				ADD_ATTR: ["data-url", "target", "rel"],
 				// プレビュー用の安全な設定
 				FORBID_TAGS: ["script", "object", "embed", "form", "input"],
 				FORBID_ATTR: ["onerror", "onload", "onclick", "onmouseover"],
@@ -63,6 +70,12 @@ function NewBlogPost() {
 		}
 		setPreview(!preview);
 	};
+
+	useEffect(() => {
+		if (preview && htmlContent && previewRef.current) {
+			hydrateLinkPreviews(previewRef.current);
+		}
+	}, [preview, htmlContent]);
 
 	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault();
@@ -199,6 +212,7 @@ function NewBlogPost() {
 								/>
 							)}
 							<div
+								ref={previewRef}
 								className="prose prose-lg dark:prose-invert max-w-none"
 								dangerouslySetInnerHTML={{ __html: htmlContent }}
 							/>

--- a/apps/web/src/routes/blog/$id.tsx
+++ b/apps/web/src/routes/blog/$id.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import DOMPurify from "dompurify";
 import { motion } from "framer-motion";
 import { marked } from "marked";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import {
 	RiArrowLeftLine,
@@ -16,6 +16,10 @@ import {
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+	hydrateLinkPreviews,
+	linkPreviewExtension,
+} from "@/utils/link-preview";
 import { trpc } from "@/utils/trpc";
 
 export const Route = createFileRoute("/blog/$id")({
@@ -29,6 +33,7 @@ function BlogPostPage() {
 	});
 	const [copied, setCopied] = useState(false);
 	const [htmlContent, setHtmlContent] = useState("");
+	const contentRef = useRef<HTMLDivElement>(null);
 
 	const pageUrl =
 		typeof window !== "undefined"
@@ -44,12 +49,13 @@ function BlogPostPage() {
 				breaks: true,
 				pedantic: false,
 			});
+			marked.use(linkPreviewExtension);
 
 			// Parse markdown and sanitize HTML
 			const rawHtml = marked(post.content) as string;
 			const cleanHtml = DOMPurify.sanitize(rawHtml, {
 				// 許可する属性を明示的に指定
-				ADD_ATTR: ["target", "rel"],
+				ADD_ATTR: ["target", "rel", "data-url"],
 				// 危険なタグを除去
 				FORBID_TAGS: ["script", "object", "embed", "form", "input"],
 				// 危険な属性を除去
@@ -60,6 +66,13 @@ function BlogPostPage() {
 			setHtmlContent(cleanHtml);
 		}
 	}, [post?.content]);
+
+	// Hydrate link previews after HTML is rendered
+	useEffect(() => {
+		if (htmlContent && contentRef.current) {
+			hydrateLinkPreviews(contentRef.current);
+		}
+	}, [htmlContent]);
 
 	const formatDate = (date: Date | string) => {
 		return new Date(date).toLocaleDateString("ja-JP", {
@@ -282,6 +295,7 @@ function BlogPostPage() {
 						transition={{ delay: 0.5, duration: 0.6 }}
 					>
 						<div
+							ref={contentRef}
 							dangerouslySetInnerHTML={{ __html: htmlContent }}
 							className="prose-h1:mt-8 prose-h2:mt-6 prose-h3:mt-4 prose-h1:mb-4 prose-h2:mb-3 prose-h3:mb-2 prose-li:mb-2 prose-p:mb-4 prose-ol:list-decimal prose-ul:list-disc prose-code:rounded-md prose-img:rounded-lg prose-pre:border prose-blockquote:border-primary prose-hr:border-border prose-pre:border-border prose-blockquote:border-l-4 prose-code:bg-accent/20 prose-pre:bg-accent/10 prose-code:px-1.5 prose-code:py-0.5 prose-blockquote:pl-4 prose-ol:pl-6 prose-ul:pl-6 prose-headings:font-bold prose-a:text-primary prose-h1:text-3xl prose-h2:text-2xl prose-h3:text-xl prose-blockquote:italic prose-p:leading-relaxed prose-a:underline-offset-4 prose-img:shadow-lg prose-code:before:content-none prose-code:after:content-none hover:prose-a:text-primary/80"
 						/>

--- a/apps/web/src/utils/link-preview.ts
+++ b/apps/web/src/utils/link-preview.ts
@@ -1,0 +1,131 @@
+import type { MarkedExtension, Tokens } from "marked";
+
+export interface OgpData {
+	title: string;
+	description: string;
+	image: string;
+	siteName: string;
+	favicon: string | null;
+	url: string;
+}
+
+const ogpCache = new Map<string, OgpData>();
+
+export async function fetchOgpData(url: string): Promise<OgpData | null> {
+	if (ogpCache.has(url)) {
+		return ogpCache.get(url)!;
+	}
+
+	try {
+		const apiBase = import.meta.env.VITE_SERVER_URL;
+		const res = await fetch(
+			`${apiBase}/api/ogp?url=${encodeURIComponent(url)}`,
+		);
+		if (!res.ok) return null;
+		const data: OgpData = await res.json();
+		ogpCache.set(url, data);
+		return data;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Custom marked extension that detects standalone URLs in paragraphs
+ * and replaces them with link preview placeholder HTML.
+ *
+ * A "standalone URL" is a paragraph that contains only a single link
+ * (e.g., a bare URL on its own line).
+ */
+export const linkPreviewExtension: MarkedExtension = {
+	renderer: {
+		paragraph({ tokens }: Tokens.Paragraph) {
+			// Check if paragraph contains only a single link token
+			// (possibly with surrounding whitespace text tokens)
+			const nonEmptyTokens = tokens.filter(
+				(t) => !(t.type === "text" && t.raw.trim() === ""),
+			);
+
+			if (nonEmptyTokens.length === 1 && nonEmptyTokens[0].type === "link") {
+				const link = nonEmptyTokens[0] as Tokens.Link;
+				const href = link.href;
+
+				// Only create preview for http(s) URLs
+				if (href.startsWith("http://") || href.startsWith("https://")) {
+					const escapedUrl = href
+						.replace(/&/g, "&amp;")
+						.replace(/"/g, "&quot;")
+						.replace(/</g, "&lt;")
+						.replace(/>/g, "&gt;");
+					const hostname = new URL(href).hostname;
+
+					return `<div class="link-preview" data-url="${escapedUrl}">
+  <a href="${escapedUrl}" target="_blank" rel="noopener noreferrer" class="link-preview-card">
+    <div class="link-preview-body">
+      <div class="link-preview-title">${escapedUrl}</div>
+      <div class="link-preview-site">
+        <span>${hostname}</span>
+      </div>
+    </div>
+  </a>
+</div>\n`;
+				}
+			}
+
+			// Default paragraph rendering
+			return false;
+		},
+	},
+};
+
+/**
+ * After markdown HTML is set in the DOM, find all link preview placeholders
+ * and populate them with fetched OGP data.
+ */
+export async function hydrateLinkPreviews(
+	container: HTMLElement,
+): Promise<void> {
+	const previews = container.querySelectorAll<HTMLDivElement>(
+		".link-preview[data-url]",
+	);
+	if (previews.length === 0) return;
+
+	const fetchPromises = Array.from(previews).map(async (el) => {
+		const url = el.dataset.url;
+		if (!url) return;
+
+		const data = await fetchOgpData(url);
+		if (!data) return;
+
+		const card = el.querySelector(".link-preview-card") as HTMLAnchorElement;
+		if (!card) return;
+
+		const title = data.title || url;
+		const description = data.description || "";
+		const siteName = data.siteName || new URL(url).hostname;
+		const favicon = data.favicon || "";
+		const image = data.image || "";
+
+		const escapeHtml = (str: string) =>
+			str
+				.replace(/&/g, "&amp;")
+				.replace(/</g, "&lt;")
+				.replace(/>/g, "&gt;")
+				.replace(/"/g, "&quot;");
+
+		card.innerHTML = `${
+			image
+				? `<div class="link-preview-image"><img src="${escapeHtml(image)}" alt="" loading="lazy" /></div>`
+				: ""
+		}<div class="link-preview-body">
+      <div class="link-preview-title">${escapeHtml(title)}</div>
+      ${description ? `<div class="link-preview-description">${escapeHtml(description)}</div>` : ""}
+      <div class="link-preview-site">
+        ${favicon ? `<img src="${escapeHtml(favicon)}" alt="" class="link-preview-favicon" />` : ""}
+        <span>${escapeHtml(siteName)}</span>
+      </div>
+    </div>`;
+	});
+
+	await Promise.allSettled(fetchPromises);
+}


### PR DESCRIPTION
Add automatic link preview cards for URLs that appear on their own line in blog posts. When a paragraph contains only a single link, it renders as a rich preview card showing the page's title, description, image, and favicon fetched via OGP metadata.

- Add /api/ogp endpoint to server for fetching OGP metadata from URLs
- Create marked extension to detect standalone URLs and render placeholders
- Hydrate previews client-side with fetched OGP data (with in-memory cache)
- Add responsive link preview card styles (horizontal on desktop, vertical on mobile)
- Apply link preview to blog post page and admin editor preview

https://claude.ai/code/session_012Hk3S8Zz12G6yzU4tasWwv