### PR TITLE
refactor(web): home ルートを -components 構造に整理

### DIFF
--- a/apps/web/src/routes/-components/fragments/Blog.tsx
+++ b/apps/web/src/routes/-components/fragments/Blog.tsx
@@ -22,14 +22,14 @@ interface BlogPostProps {
 	index: number;
 }
 
-function BlogPost({
+const BlogPost = ({
 	id,
 	title,
 	excerpt,
 	createdAt,
 	views,
 	index,
-}: BlogPostProps) {
+}: BlogPostProps) => {
 	return (
 		<Link to="/blog/$id" params={{ id: String(id) }} className="block">
 			<motion.article
@@ -64,9 +64,9 @@ function BlogPost({
 			</motion.article>
 		</Link>
 	);
-}
+};
 
-function BlogHeader({ isAdmin }: { isAdmin: boolean }) {
+const BlogHeader = ({ isAdmin }: { isAdmin: boolean }) => {
 	return (
 		<div className="mb-12 flex items-center justify-between">
 			<motion.h2
@@ -103,9 +103,9 @@ function BlogHeader({ isAdmin }: { isAdmin: boolean }) {
 			</motion.div>
 		</div>
 	);
-}
+};
 
-function BlogLoading() {
+const BlogLoading = () => {
 	return (
 		<motion.section
 			className="bg-muted/30 px-6 py-20 md:px-12 lg:px-24"
@@ -121,9 +121,9 @@ function BlogLoading() {
 			</div>
 		</motion.section>
 	);
-}
+};
 
-export function Blog() {
+export const Blog = () => {
 	const {
 		data: posts,
 		isLoading,
@@ -176,4 +176,4 @@ export function Blog() {
 			</div>
 		</motion.section>
 	);
-}
+};

--- a/apps/web/src/routes/-components/fragments/Favorites.tsx
+++ b/apps/web/src/routes/-components/fragments/Favorites.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/constants/animations";
 import { FAVORITES } from "@/constants/favorites";
 
-export function Favorites() {
+export const Favorites = () => {
 	return (
 		<motion.section
 			className="px-6 py-20 md:px-12 lg:px-24"
@@ -91,4 +91,4 @@ export function Favorites() {
 			</div>
 		</motion.section>
 	);
-}
+};

--- a/apps/web/src/routes/-components/fragments/Hero.tsx
+++ b/apps/web/src/routes/-components/fragments/Hero.tsx
@@ -18,7 +18,7 @@ import { type SocialPlatform, trackSocialClick } from "@/utils/analytics";
 
 const NAME_CHARACTERS = ["ぶ", "り", "お"] as const;
 
-export function Hero() {
+export const Hero = () => {
 	const [enableAnimations, setEnableAnimations] = useState(false);
 	const [isMobile, setIsMobile] = useState(false);
 
@@ -187,4 +187,4 @@ export function Hero() {
 			</MeshGradientCard>
 		</motion.section>
 	);
-}
+};

--- a/apps/web/src/routes/-components/fragments/Lt.tsx
+++ b/apps/web/src/routes/-components/fragments/Lt.tsx
@@ -5,7 +5,7 @@ import {
 	smoothTransition,
 } from "@/constants/animations";
 
-export function Lt() {
+export const Lt = () => {
 	return (
 		<motion.section
 			className="px-6 py-20 md:px-12 lg:px-24"
@@ -40,4 +40,4 @@ export function Lt() {
 			</div>
 		</motion.section>
 	);
-}
+};

--- a/apps/web/src/routes/-components/pages/HomePage.tsx
+++ b/apps/web/src/routes/-components/pages/HomePage.tsx
@@ -1,0 +1,55 @@
+import { lazy, Suspense, useEffect, useState } from "react";
+import { Blog } from "../fragments/Blog";
+import { Favorites } from "../fragments/Favorites";
+import { Hero } from "../fragments/Hero";
+import { Lt } from "../fragments/Lt";
+
+// Lazy load the 3D background for better initial bundle size
+const ThreeBackground = lazy(() =>
+	import("@/components/backgrounds/ThreeBackground").then((module) => ({
+		default: module.ThreeBackground,
+	})),
+);
+
+export const HomePage = () => {
+	const [shouldLoadBackground, setShouldLoadBackground] = useState(false);
+
+	useEffect(() => {
+		// Defer loading of ThreeBackground until after initial render
+		// This ensures critical content (Hero) loads first for better LCP
+		if ("requestIdleCallback" in window) {
+			// Use requestIdleCallback if available (most browsers)
+			requestIdleCallback(
+				() => {
+					setShouldLoadBackground(true);
+				},
+				{ timeout: 2000 }, // Fallback timeout
+			);
+		} else {
+			// Fallback for Safari and older browsers
+			const timer = setTimeout(() => {
+				setShouldLoadBackground(true);
+			}, 100);
+			return () => clearTimeout(timer);
+		}
+	}, []);
+
+	return (
+		<>
+			{/* 3D Background - deferred load for better LCP */}
+			{shouldLoadBackground && (
+				<Suspense fallback={null}>
+					<ThreeBackground />
+				</Suspense>
+			)}
+
+			<main className="relative z-10 min-h-screen">
+				{/* Main content - loads immediately for optimal LCP */}
+				<Hero />
+				<Favorites />
+				<Lt />
+				<Blog />
+			</main>
+		</>
+	);
+};

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,60 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { lazy, Suspense, useEffect, useState } from "react";
-import { Blog } from "@/components/home/blog";
-import { Favorites } from "@/components/home/favorites";
-import { Hero } from "@/components/home/hero";
-import { Lt } from "@/components/home/lt";
-
-// Lazy load the 3D background for better initial bundle size
-const ThreeBackground = lazy(() =>
-	import("@/components/backgrounds/ThreeBackground").then((module) => ({
-		default: module.ThreeBackground,
-	})),
-);
+import { HomePage } from "./-components/pages/HomePage";
 
 export const Route = createFileRoute("/")({
-	component: HomeComponent,
+	component: HomePage,
 });
-
-function HomeComponent() {
-	const [shouldLoadBackground, setShouldLoadBackground] = useState(false);
-
-	useEffect(() => {
-		// Defer loading of ThreeBackground until after initial render
-		// This ensures critical content (Hero) loads first for better LCP
-		if ("requestIdleCallback" in window) {
-			// Use requestIdleCallback if available (most browsers)
-			requestIdleCallback(
-				() => {
-					setShouldLoadBackground(true);
-				},
-				{ timeout: 2000 }, // Fallback timeout
-			);
-		} else {
-			// Fallback for Safari and older browsers
-			const timer = setTimeout(() => {
-				setShouldLoadBackground(true);
-			}, 100);
-			return () => clearTimeout(timer);
-		}
-	}, []);
-
-	return (
-		<>
-			{/* 3D Background - deferred load for better LCP */}
-			{shouldLoadBackground && (
-				<Suspense fallback={null}>
-					<ThreeBackground />
-				</Suspense>
-			)}
-
-			<main className="relative z-10 min-h-screen">
-				{/* Main content - loads immediately for optimal LCP */}
-				<Hero />
-				<Favorites />
-				<Lt />
-				<Blog />
-			</main>
-		</>
-	);
-}


### PR DESCRIPTION
- HomeComponent を routes/-components/pages/HomePage.tsx に抽出
- components/home/{hero,favorites,lt,blog}.tsx を routes/-components/fragments/ に移動 (PascalCase 化)
- routes/index.tsx を 60 → 6 行に圧縮 (createFileRoute + HomePage 参照だけ)
- 全コンポーネントをアロー関数 named const 表記に統一
- ThreeBackground は汎用 UI として components/backgrounds/ に温存