### PR TITLE
refactor(web): admin-blog フォームを TanStack Form で再構築

### DIFF
--- a/apps/web/src/features/admin-blog/hooks/use-blog-form.ts
+++ b/apps/web/src/features/admin-blog/hooks/use-blog-form.ts
@@ -1,4 +1,6 @@
-import { useEffect, useId, useRef, useState } from "react";
+import { useForm } from "@tanstack/react-form";
+import type React from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { renderMarkdownPreview } from "@/features/blog/utils/markdown-preview";
 import { parseTagsInput } from "@/features/blog/utils/parse-tags";
 import { useImageUpload } from "@/hooks/use-image-upload";
@@ -22,24 +24,66 @@ export type BlogFormValues = {
 	published: boolean;
 };
 
+type BlogFormFields = {
+	title: string;
+	content: string;
+	excerpt: string;
+	coverImage: string;
+	tags: string;
+	published: boolean;
+};
+
+const EMPTY_FIELDS: BlogFormFields = {
+	title: "",
+	content: "",
+	excerpt: "",
+	coverImage: "",
+	tags: "",
+	published: false,
+};
+
+type UseBlogFormParams = {
+	initialData?: BlogFormInitialData;
+	onSubmit: (values: BlogFormValues) => void;
+};
+
 /**
- * ブログ記事の作成・編集フォームで共通利用する state / 振る舞いをまとめたフック。
+ * ブログ記事の作成・編集フォームで共通利用するフォームインスタンス / 振る舞いをまとめたフック。
  * initialData が後から（非同期で）渡された場合にも内部 state を反映する。
  */
-export function useBlogForm(initialData?: BlogFormInitialData) {
-	const [title, setTitle] = useState(initialData?.title ?? "");
-	const [content, setContent] = useState(initialData?.content ?? "");
-	const [excerpt, setExcerpt] = useState(initialData?.excerpt ?? "");
-	const [coverImage, setCoverImage] = useState(initialData?.coverImage ?? "");
-	const [tags, setTags] = useState(initialData?.tags ?? "");
-	const [published, setPublished] = useState(initialData?.published ?? false);
+export function useBlogForm({ initialData, onSubmit }: UseBlogFormParams) {
+	const form = useForm({
+		defaultValues: initialData ?? EMPTY_FIELDS,
+		onSubmit: ({ value }) => {
+			onSubmit({
+				title: value.title,
+				content: value.content,
+				excerpt: value.excerpt,
+				coverImage: value.coverImage,
+				tags: parseTagsInput(value.tags),
+				published: value.published,
+			});
+		},
+	});
+
 	const [preview, setPreview] = useState(false);
 	const [htmlContent, setHtmlContent] = useState("");
-
-	const { textareaProps } = useImageUpload(setContent);
 	const previewRef = useRef<HTMLDivElement>(null);
 
-	// フォーム要素用の一意な ID を生成
+	const setContent = useCallback<React.Dispatch<React.SetStateAction<string>>>(
+		(value) => {
+			const current = form.getFieldValue("content");
+			const next =
+				typeof value === "function"
+					? (value as (prev: string) => string)(current)
+					: value;
+			form.setFieldValue("content", next);
+		},
+		[form],
+	);
+
+	const { textareaProps } = useImageUpload(setContent);
+
 	const titleId = useId();
 	const excerptId = useId();
 	const contentId = useId();
@@ -47,68 +91,37 @@ export function useBlogForm(initialData?: BlogFormInitialData) {
 	const tagsId = useId();
 	const publishedId = useId();
 
-	// initialData（編集対象記事）が後から取得された場合に state を反映する
 	useEffect(() => {
 		if (!initialData) return;
-		setTitle(initialData.title);
-		setContent(initialData.content);
-		setExcerpt(initialData.excerpt);
-		setCoverImage(initialData.coverImage);
-		setTags(initialData.tags);
-		setPublished(initialData.published);
-	}, [initialData]);
+		form.reset(initialData);
+	}, [initialData, form]);
 
 	const handlePreview = () => {
+		const content = form.getFieldValue("content");
 		if (content) {
 			setHtmlContent(renderMarkdownPreview(content));
 		}
 		setPreview((prev) => !prev);
 	};
 
-	// プレビュー切替後に link preview を hydrate する
 	useEffect(() => {
 		if (preview && htmlContent && previewRef.current) {
 			hydrateLinkPreviews(previewRef.current);
 		}
 	}, [preview, htmlContent]);
 
-	const getFormValues = (): BlogFormValues => ({
-		title,
-		content,
-		excerpt,
-		coverImage,
-		tags: parseTagsInput(tags),
-		published,
-	});
-
 	return {
-		// state
-		title,
-		setTitle,
-		content,
-		setContent,
-		excerpt,
-		setExcerpt,
-		coverImage,
-		setCoverImage,
-		tags,
-		setTags,
-		published,
-		setPublished,
+		form,
 		preview,
 		htmlContent,
-		// refs / props
 		previewRef,
 		textareaProps,
-		// IDs
 		titleId,
 		excerptId,
 		contentId,
 		coverImageId,
 		tagsId,
 		publishedId,
-		// handlers
 		handlePreview,
-		getFormValues,
 	};
 }

--- a/apps/web/src/routes/admin/blog/-components/fragments/BlogForm.tsx
+++ b/apps/web/src/routes/admin/blog/-components/fragments/BlogForm.tsx
@@ -31,18 +31,7 @@ export const BlogForm = ({
 }: BlogFormProps) => {
 	const navigate = useNavigate();
 	const {
-		title,
-		setTitle,
-		content,
-		setContent,
-		excerpt,
-		setExcerpt,
-		coverImage,
-		setCoverImage,
-		tags,
-		setTags,
-		published,
-		setPublished,
+		form,
 		preview,
 		htmlContent,
 		previewRef,
@@ -54,13 +43,7 @@ export const BlogForm = ({
 		tagsId,
 		publishedId,
 		handlePreview,
-		getFormValues,
-	} = useBlogForm(initialData);
-
-	const handleSubmit = (e: React.FormEvent) => {
-		e.preventDefault();
-		onSubmit(getFormValues());
-	};
+	} = useBlogForm({ initialData, onSubmit });
 
 	return (
 		<motion.div
@@ -87,73 +70,110 @@ export const BlogForm = ({
 			</div>
 
 			{!preview ? (
-				<form onSubmit={handleSubmit} className="space-y-6">
-					<div>
-						<Label htmlFor={titleId}>タイトル *</Label>
-						<Input
-							id={titleId}
-							value={title}
-							onChange={(e) => setTitle(e.target.value)}
-							required
-							placeholder="記事のタイトル"
-						/>
-					</div>
+				<form
+					onSubmit={(e) => {
+						e.preventDefault();
+						e.stopPropagation();
+						form.handleSubmit();
+					}}
+					className="space-y-6"
+				>
+					<form.Field name="title">
+						{(field) => (
+							<div>
+								<Label htmlFor={titleId}>タイトル *</Label>
+								<Input
+									id={titleId}
+									value={field.state.value}
+									onChange={(e) => field.handleChange(e.target.value)}
+									onBlur={field.handleBlur}
+									required
+									placeholder="記事のタイトル"
+								/>
+							</div>
+						)}
+					</form.Field>
 
-					<div>
-						<Label htmlFor={excerptId}>概要</Label>
-						<Input
-							id={excerptId}
-							value={excerpt}
-							onChange={(e) => setExcerpt(e.target.value)}
-							placeholder="記事の概要（一覧ページに表示されます）"
-						/>
-					</div>
+					<form.Field name="excerpt">
+						{(field) => (
+							<div>
+								<Label htmlFor={excerptId}>概要</Label>
+								<Input
+									id={excerptId}
+									value={field.state.value}
+									onChange={(e) => field.handleChange(e.target.value)}
+									onBlur={field.handleBlur}
+									placeholder="記事の概要（一覧ページに表示されます）"
+								/>
+							</div>
+						)}
+					</form.Field>
 
-					<div>
-						<Label htmlFor={contentId}>本文（Markdown）</Label>
-						<textarea
-							id={contentId}
-							value={content}
-							onChange={(e) => setContent(e.target.value)}
-							className="h-96 w-full resize-y rounded-md border bg-background p-3 text-foreground"
-							placeholder="Markdownで記事を書く... (画像をペーストまたはドラッグ&ドロップできます)"
-							{...textareaProps}
-						/>
-					</div>
+					<form.Field name="content">
+						{(field) => (
+							<div>
+								<Label htmlFor={contentId}>本文（Markdown）</Label>
+								<textarea
+									id={contentId}
+									value={field.state.value}
+									onChange={(e) => field.handleChange(e.target.value)}
+									onBlur={field.handleBlur}
+									className="h-96 w-full resize-y rounded-md border bg-background p-3 text-foreground"
+									placeholder="Markdownで記事を書く... (画像をペーストまたはドラッグ&ドロップできます)"
+									{...textareaProps}
+								/>
+							</div>
+						)}
+					</form.Field>
 
-					<div>
-						<Label htmlFor={coverImageId}>カバー画像URL</Label>
-						<Input
-							id={coverImageId}
-							value={coverImage}
-							onChange={(e) => setCoverImage(e.target.value)}
-							placeholder="https://example.com/image.jpg"
-							type="url"
-						/>
-					</div>
+					<form.Field name="coverImage">
+						{(field) => (
+							<div>
+								<Label htmlFor={coverImageId}>カバー画像URL</Label>
+								<Input
+									id={coverImageId}
+									value={field.state.value}
+									onChange={(e) => field.handleChange(e.target.value)}
+									onBlur={field.handleBlur}
+									placeholder="https://example.com/image.jpg"
+									type="url"
+								/>
+							</div>
+						)}
+					</form.Field>
 
-					<div>
-						<Label htmlFor={tagsId}>タグ（カンマ区切り）</Label>
-						<Input
-							id={tagsId}
-							value={tags}
-							onChange={(e) => setTags(e.target.value)}
-							placeholder="React, TypeScript, Web開発"
-						/>
-					</div>
+					<form.Field name="tags">
+						{(field) => (
+							<div>
+								<Label htmlFor={tagsId}>タグ（カンマ区切り）</Label>
+								<Input
+									id={tagsId}
+									value={field.state.value}
+									onChange={(e) => field.handleChange(e.target.value)}
+									onBlur={field.handleBlur}
+									placeholder="React, TypeScript, Web開発"
+								/>
+							</div>
+						)}
+					</form.Field>
 
-					<div className="flex items-center gap-2">
-						<input
-							id={publishedId}
-							type="checkbox"
-							checked={published}
-							onChange={(e) => setPublished(e.target.checked)}
-							className="h-4 w-4"
-						/>
-						<Label htmlFor={publishedId} className="cursor-pointer">
-							公開する
-						</Label>
-					</div>
+					<form.Field name="published">
+						{(field) => (
+							<div className="flex items-center gap-2">
+								<input
+									id={publishedId}
+									type="checkbox"
+									checked={field.state.value}
+									onChange={(e) => field.handleChange(e.target.checked)}
+									onBlur={field.handleBlur}
+									className="h-4 w-4"
+								/>
+								<Label htmlFor={publishedId} className="cursor-pointer">
+									公開する
+								</Label>
+							</div>
+						)}
+					</form.Field>
 
 					<div className="flex gap-4">
 						<Button type="submit" disabled={isPending}>
@@ -163,14 +183,18 @@ export const BlogForm = ({
 					</div>
 				</form>
 			) : (
-				<BlogPreview
-					title={title}
-					excerpt={excerpt}
-					coverImage={coverImage}
-					htmlContent={htmlContent}
-					tags={tags}
-					previewRef={previewRef}
-				/>
+				<form.Subscribe selector={(s) => s.values}>
+					{(values) => (
+						<BlogPreview
+							title={values.title}
+							excerpt={values.excerpt}
+							coverImage={values.coverImage}
+							htmlContent={htmlContent}
+							tags={values.tags}
+							previewRef={previewRef}
+						/>
+					)}
+				</form.Subscribe>
 			)}
 		</motion.div>
 	);


### PR DESCRIPTION
useState ベースで手書きしていた useBlogForm を @tanstack/react-form の useForm に置き換え、各入力を <form.Field> パターンに刷新。tags 入力は
カンマ区切り文字列のまま保持し、submit 時に parseTagsInput で配列化する
ことで呼び出し元の BlogFormValues 互換を維持。