### PR TITLE
fix(og): OG 画像エンドポイントの HEAD で text/html を返す問題を修正

### DIFF
--- a/apps/web/src/routes/api/og/blog/$id.ts
+++ b/apps/web/src/routes/api/og/blog/$id.ts
@@ -1,16 +1,25 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { env } from "cloudflare:workers";
 
+// HEAD も明示する。未定義だと TanStack が SSR にフォールスルーし image/png ではなく text/html を返すため、HEAD で Content-Type を確認する SNS クローラーが画像と認識できない
+function proxyOgImage(
+	rawId: string,
+	request: Request,
+): Response | Promise<Response> {
+	const id = Number(rawId);
+	if (!Number.isInteger(id) || id <= 0) {
+		return new Response("Not Found", { status: 404 });
+	}
+	return env.API.fetch(
+		new Request(`https://api/og/blog/${id}`, { method: request.method }),
+	);
+}
+
 export const Route = createFileRoute("/api/og/blog/$id")({
 	server: {
 		handlers: {
-			GET: async ({ params }) => {
-				const id = Number(params.id);
-				if (!Number.isInteger(id) || id <= 0) {
-					return new Response("Not Found", { status: 404 });
-				}
-				return env.API.fetch(new Request(`https://api/og/blog/${id}`));
-			},
+			GET: ({ params, request }) => proxyOgImage(params.id, request),
+			HEAD: ({ params, request }) => proxyOgImage(params.id, request),
 		},
 	},
 });


### PR DESCRIPTION
GET は image/png を返すが HEAD は SSR にフォールスルーし text/html を返していた。TanStack Start は handlers[method] のみ解決するため
HEAD 未定義時は HTML レンダラへ落ちる。HEAD ハンドラを追加し
request.method を service binding 経由で API Worker に転送する (Hono が HEAD を自動処理し image/png ヘッダ + 空ボディを返す)。