### PR TITLE
fix(web): SSR 時に Outlet を isLoading でラップせず記事固有 OGP を出力

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -5,12 +5,10 @@ import {
 	Outlet,
 	Scripts,
 	createRootRouteWithContext,
-	useRouterState,
 } from "@tanstack/react-router";
 import { Suspense, lazy } from "react";
 
 import Header from "@/components/layouts/header";
-import Loader from "@/components/loader";
 import NotFound from "@/components/not-found";
 import { ThemeProvider } from "@/components/providers/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
@@ -166,9 +164,6 @@ function RootDocument({ children }: { children: React.ReactNode }) {
 
 function RootComponent() {
 	const { queryClient } = Route.useRouteContext();
-	const isFetching = useRouterState({
-		select: (s) => s.isLoading,
-	});
 
 	return (
 		<trpc.Provider client={trpcClient} queryClient={queryClient}>
@@ -182,7 +177,7 @@ function RootComponent() {
 					<div className="min-h-screen bg-transparent">
 						<Header />
 						<main className="relative pt-16">
-							{isFetching ? <Loader /> : <Outlet />}
+							<Outlet />
 						</main>
 					</div>
 					<Toaster richColors />


### PR DESCRIPTION
## 概要
ブログ記事 `/blog/$id` の**記事固有 OGP が SNS クローラに検出されない**問題を修正します。調査の結果、記事ページに限らず**全ルートで本文・head が SSR されていない**状態でした。

## 原因
`apps/web/src/routes/__root.tsx` の `RootComponent` でグローバルに `Outlet` を `isLoading` でラップしていました。

```tsx
const isFetching = useRouterState({ select: (s) => s.isLoading });
...
{isFetching ? <Loader /> : <Outlet />}
```

SSR レンダリング時に `s.isLoading` が `true` になるため、サーバ側で全ページ `<Outlet />` ではなく `<Loader />` を描画。マッチしたルートが pending 扱いとなり `loaderData` が `undefined` → `head()`（`buildBlogPostHead` 等、loaderData 依存の OGP メタ生成）が走らず、`__root` の汎用 OGP だけが出力されていました。本文も SSR されません。

## 切り分けの根拠
- `/`・`/blog`・`/blog/8` すべて `#app` の中身がローディングスピナーのみ、`<title>` が常に `burio16.com`、`og:type=article` 等の記事メタが 0 件
- 一方 `/api/og/blog/$id`（OG画像エンドポイント）は 200 PNG を返す → サーバ側のデータ取得自体は正常 = 描画/head 層の問題と判明

## 修正
グローバル `isLoading` ゲートを撤去し `<Outlet />` を直接描画。

```tsx
<main className="relative pt-16">
  <Outlet />
</main>
```

ローディング表示は各ルートの `pendingComponent` と `router.tsx` の `defaultPendingComponent` が担うため UX 影響なし。不要になった `useRouterState` / `Loader` の import も削除。

## 影響
- `/blog/$id` 等で記事固有 OGP（`og:title` / `og:description` / `og:image` / `og:type=article` / canonical）と本文が SSR される
- SEO・SNS シェアのカード表示が正常化

## 確認
- [x] `bun run check-types`（型エラーなし）
- [x] pre-commit（oxfmt / oxlint）通過
- [ ] デプロイ後に `og:type=article` 出力を curl / 各 SNS カードバリデータで確認（SNS キャッシュ要再取得）

## テスト観点（レビュー用）
- 各ルートの初期ロード・遷移時にローディング表示が出るか（pendingComponent に委譲済み）
- ハイドレーション不一致が出ないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)