### PR TITLE
Update robots.txt for burio16.com and improve social media crawler handling

### DIFF
--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,4 +1,15 @@
-# robots.txt for burio.com
+# robots.txt for burio16.com
+
+# Social media crawlers fetch Open Graph / Twitter card images from /api/og/.
+# Twitterbot (and some others) do NOT honor the "Allow" directive, so a broad
+# "Disallow: /api/" would block the card image even with an "Allow: /api/og/".
+# Give these crawlers a dedicated group that does not disallow the OG path.
+User-agent: Twitterbot
+Disallow: /admin/
+
+User-agent: facebookexternalhit
+Disallow: /admin/
+
 User-agent: *
 Allow: /
 Allow: /api/og/
@@ -6,4 +17,4 @@ Disallow: /admin/
 Disallow: /api/
 
 # Sitemap location
-Sitemap: https://burio.com/sitemap.xml
+Sitemap: https://burio16.com/sitemap.xml


### PR DESCRIPTION
## Summary
Updated the robots.txt configuration to reflect the domain change from burio.com to burio16.com, and improved handling of social media crawlers to ensure Open Graph and Twitter card images are properly fetched.

## Key Changes
- Updated domain references from burio.com to burio16.com in sitemap URL and file header
- Added dedicated User-Agent rules for Twitterbot and facebookexternalhit that only disallow `/admin/` paths
- Maintained the general `User-agent: *` rule that disallows both `/admin/` and `/api/` (except `/api/og/`)
- Added explanatory comments documenting why social media crawlers need special handling

## Implementation Details
Social media crawlers like Twitterbot do not properly honor the "Allow" directive when a broader "Disallow" rule exists for the same path. By creating dedicated User-Agent groups for these crawlers that only disallow `/admin/`, we ensure they can successfully fetch Open Graph and Twitter card images from `/api/og/` without being blocked by the general `/api/` disallow rule.

https://claude.ai/code/session_01Eek3gB1aFKpFB3BYPBQpn8